### PR TITLE
Update ShortcodesPlugin.php

### DIFF
--- a/plugins/shortcodes/ShortcodesPlugin.php
+++ b/plugins/shortcodes/ShortcodesPlugin.php
@@ -40,7 +40,7 @@ class ShortcodesPlugin extends BasePlugin
 		}
 	}
 
-	public function hookAddTwigExtension()
+	public function addTwigExtension()
 	{
 		Craft::import('plugins.shortcodes.lib.Shortcodes');
 		Craft::import('plugins.shortcodes.twigextensions.ShortcodesTwigExtension');


### PR DESCRIPTION
I just started using it and Craft yelled at me saying `hookAddTwigExtension` has been deprecated in favor of `addTwigExtension`. This PR should remove that warning. 

Thank you for this plugin, it's working great!
